### PR TITLE
Shorten text for button

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -15,7 +15,7 @@ const panel   = require('sdk/panel').Panel({
 
 let button = ToggleButton({
 	id : 'urltoqr',
-	label : 'Click to convert URL to QR code',
+	label : 'URL to QR code',
 	icon  : {
 		"32": data.url("images.png")
 	},

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
 
   "manifest_version": 2,
-  "name": "Url to QrCode",
-  "description": "Converts tab URL to QrCode.",
+  "name": "URL to QR code",
+  "description": "Converts the tab URL to QR code.",
   "author": "Saeed Moghadam",
   "version": "0.8",
   "icons": {
@@ -12,7 +12,7 @@
   "browser_action": {
     "browser_style": false,
     "default_icon": "data/images.png",
-    "default_title" : "URL to QRCode",
+    "default_title" : "URL to QR code",
     "default_popup": "data/index.html"
   },
 

--- a/manifest.json
+++ b/manifest.json
@@ -12,7 +12,7 @@
   "browser_action": {
     "browser_style": false,
     "default_icon": "data/images.png",
-    "default_title" : "Click to convert URL to QRCode",
+    "default_title" : "URL to QRCode",
     "default_popup": "data/index.html"
   },
 


### PR DESCRIPTION
"Click to do… something" is unnecessary. It is obvious you have to click on the button… Also this looks better in the overflow menu.